### PR TITLE
Remove cloning repo in docker file

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -5,7 +5,7 @@ LABEL maintainer="sboddu@ebi.ac.uk"
 # Environment variable
 ENV PYTHONUNBUFFERED TRUE
 
-RUN git clone --depth 1 https://github.com/Ensembl/ensembl-2020-genome-search.git /usr/src/genome-search
+COPY . /usr/src/genome-search
 
 WORKDIR /usr/src/genome-search
 

--- a/docker/Dockerfile.stage
+++ b/docker/Dockerfile.stage
@@ -5,7 +5,7 @@ LABEL maintainer="sboddu@ebi.ac.uk"
 # Environment variable
 ENV PYTHONUNBUFFERED TRUE
 
-RUN git clone --depth 1 https://github.com/Ensembl/ensembl-2020-genome-search.git /usr/src/genome-search
+COPY . /usr/src/genome-search
 
 WORKDIR /usr/src/genome-search
 


### PR DESCRIPTION
Cloning repository from git inside dockerfile always clones default branch which fails in gitlab CICD while running CICD for other than a defaullt branch.