### PR TITLE
Update gitlab-ci for WP-HH staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,6 +126,15 @@ Staging:EHK-HH:
   only:
   - dev
 
+# Deploy staging to WP-HX cluster
+Staging:WP-HX:
+  extends: .deploy-wp
+  environment:
+    name : wp-hx-staging
+
+  only:
+  - dev
+
 # Deploy staging to K8S_CLUSTER : WP-HH cluster
 Staging:WP-HH:
   extends: .deploy-wp

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,7 @@ Staging:WP-HX:
   only:
   - dev
 
-# Deploy staging to K8S_CLUSTER : WP-HH cluster
+# Deploy staging to WP-HH cluster
 Staging:WP-HH:
   extends: .deploy-wp
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,11 +126,11 @@ Staging:EHK-HH:
   only:
   - dev
 
-# Deploy staging
-Staging:WP-HX:
+# Deploy staging to K8S_CLUSTER : WP-HH cluster
+Staging:WP-HH:
   extends: .deploy-wp
   environment:
-    name : wp-hx-staging
+    name : wp-hh-staging
 
   only:
   - dev


### PR DESCRIPTION
I have changed the `.gitlab-ci.yml` file based on this documentation: https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=ENSWEB&title=Deploying+new+site+on+WP-k8s+Cluster