### PR TITLE
Change genome_id for human GRCh38

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,10 @@ stages:
   image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
 
   script:
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
-  - git -C ensembl-client-caas-deploy/ checkout migration/wp-hx
-  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_service.yaml
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
+  - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
+  - git -C ensembl-k8s-manifests/ checkout wp-k8s
+  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
+  - kubectl apply -f ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
 
 .deploy-wp-review:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,24 +61,6 @@ stages:
   - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
   - kubectl apply -f ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
 
-# Template to deploy to EHK k8s cluster
-.deploy-ehk:
-  stage: deploy
-  image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
-  before_script:
-  - export KUBECONFIG=/etc/deploy/config
-  - mkdir -p /etc/deploy
-  - echo ${EMBASSY_KUBECONFIG} | base64 -d > ${KUBECONFIG}
-
-  script:
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
-  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - sed -i "s#<DEPLOYMENT_ENV>#${DEPLOYENV}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - sed -i "s#<DEPLOYMENT_ENV>#${DEPLOYENV}#g" ensembl-client-caas-deploy/ensembl_genome_search_service.yaml
-  - kubectl config use-context $KUBE_CONTEXT
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_service.yaml
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-
 variables:
   CONTAINER_IMAGE: $GITLAB_REGISTRY_URL/$GITLAB_REGISTRY_NAMESPACE/${CI_PROJECT_NAME}:${CI_COMMIT_SHORT_SHA}
   DOCKERFILE: Dockerfile.prod
@@ -129,15 +111,6 @@ Docker-IMG:review:
 
   when: manual
 
-# Deploy staging to EHK-HH cluster
-Staging:EHK-HH:
-  extends: .deploy-ehk
-  variables:
-    DEPLOYENV: staging
-    KUBE_CONTEXT: ens-stage-ctx
-  only:
-  - dev
-
 # Deploy staging to WP-HX cluster
 Staging:WP-HX:
   extends: .deploy-wp
@@ -155,18 +128,6 @@ Staging:WP-HH:
 
   only:
   - dev
-
-# Deploy Live to EHK-HH cluster
-Live:EHK-HH:
-  extends: .deploy-ehk
-  variables:
-    DEPLOYENV: prod
-    KUBE_CONTEXT: ens-prod-ctx
-
-  only:
-  - master
-
-  when: manual
 
 # Deploy live to WP-HH cluster
 Live:WP-HX:
@@ -229,19 +190,6 @@ Dev:WP-HX:
 
   only:
   - dev
-
-# Deploy Feature to EHK k8s cluster
-Feature:EHK-HH:
-  extends: .deploy-ehk
-  variables:
-    DEPLOYENV: ${CI_COMMIT_REF_SLUG}
-    KUBE_CONTEXT: ens-dev-ctx
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
-
-  only:
-  - /^feature\/.*$/
-
-  when: manual
 
 # Deploy Feature to EHK k8s cluster
 Review:WP-HX:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,6 +221,15 @@ Internal:WP-HH:
   only:
   - dev
 
+# Deploy dev to WP-HX cluster
+Dev:WP-HX:
+  extends: .deploy-wp
+  environment:
+    name : wp-hx-dev
+
+  only:
+  - dev
+
 # Deploy Feature to EHK k8s cluster
 Feature:EHK-HH:
   extends: .deploy-ehk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ stages:
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_service.yaml
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
 
-.deploy-wp-feature:
+.deploy-wp-review:
   stage: deploy
   image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
 
@@ -60,8 +60,6 @@ stages:
   - git -C ensembl-client-caas-deploy/ checkout deployfeature
   - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
   - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_genome_search_service_node.yaml
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_service_node.yaml
   - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
 
 # Template to deploy to EHK k8s cluster
@@ -119,15 +117,14 @@ Docker-IMG:internal:
   - dev
 
 # Build docker image for feature_branch environment
-Docker-IMG:feature:
+Docker-IMG:review:
   extends: .build
   variables:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
     DOCKERFILE: Dockerfile.feature
 
-  only:
-  - /^feature\/.*$/
-  - /^refactor\/.*$/
+  except:
+  - /^nodeploy\/.*$/
 
   when: manual
 
@@ -237,7 +234,7 @@ Feature:EHK-HH:
   when: manual
 
 # Deploy Feature to EHK k8s cluster
-Feature:WP-HX:
+Review:WP-HX:
   extends: .deploy-wp-feature
   environment:
     name : wp-hx-dev
@@ -245,8 +242,7 @@ Feature:WP-HX:
     DEPLOYENV: ${CI_COMMIT_REF_SLUG}
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
 
-  only:
-  - /^feature\/.*$/
-  - /^refactor\/.*$/
+  except:
+  - /^nodeploy\/.*$/
 
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ stages:
   image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
 
   script:
-  - git clone https://gitlab.ebi.ac.uk/web/ensembl-k8s-manifests.git
+  - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
   - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
   - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
   - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,19 +147,6 @@ Live:WP-HH:
   only:
   - master
 
-# Deploy internal to EHK k8s cluster
-Internal:EHK-HH:
-  extends: .deploy-ehk
-  variables:
-    DEPLOYENV: internal
-    CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-internal
-    KUBE_CONTEXT: ens-dev-ctx
-
-  only:
-  - master
-
-  when: manual
-
 # Deploy internal to WP-HX cluster
 Internal:WP-HX:
   extends: .deploy-wp
@@ -191,7 +178,7 @@ Dev:WP-HX:
   only:
   - dev
 
-# Deploy Feature to EHK k8s cluster
+# Deploy Review apps to WP-HX k8s cluster
 Review:WP-HX:
   extends: .deploy-wp-review
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,8 @@ Docker-IMG:review:
     DOCKERFILE: Dockerfile.feature
 
   except:
+  - dev
+  - master  
   - /^nodeploy\/.*$/
 
   when: manual
@@ -235,7 +237,7 @@ Feature:EHK-HH:
 
 # Deploy Feature to EHK k8s cluster
 Review:WP-HX:
-  extends: .deploy-wp-feature
+  extends: .deploy-wp-review
   environment:
     name : wp-hx-dev
   variables:
@@ -243,6 +245,8 @@ Review:WP-HX:
     CONTAINER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${CI_COMMIT_REF_SLUG}
 
   except:
+  - dev
+  - master  
   - /^nodeploy\/.*$/
 
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ variables:
   DOCKER_TLS_CERTDIR: ""
 
 # Run Tests
-Test:feature:
+Test:
   stage: test
 
   image: python:3.7.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,11 +56,11 @@ stages:
   image: dockerhub.ebi.ac.uk/kamal/deploy-tools:0.1
 
   script:
-  - git clone https://gitlab.ebi.ac.uk/kamal/ensembl-client-caas-deploy.git
-  - git -C ensembl-client-caas-deploy/ checkout deployfeature
-  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
-  - kubectl apply -f ensembl-client-caas-deploy/ensembl_genome_search_deployment.yaml
+  - git clone https://gitlab.ebi.ac.uk/web/ensembl-k8s-manifests.git
+  - git -C ensembl-k8s-manifests/ checkout wp-k8s-review
+  - sed -i "s#<DOCKER_IMAGE>#${CONTAINER_IMAGE}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
+  - sed -i "s#<DEPLOYMENT_ENV>#${CI_COMMIT_REF_SLUG}#g" ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
+  - kubectl apply -f ensembl-k8s-manifests/ensembl_genome_search_deployment.yaml
 
 # Template to deploy to EHK k8s cluster
 .deploy-ehk:

--- a/APISpecification.yaml
+++ b/APISpecification.yaml
@@ -41,7 +41,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       responses:
         200:
           description: successful operation
@@ -100,7 +100,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       responses:
         200:
           description: successful operation
@@ -134,7 +134,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       responses:
         200:
           description: successful operation
@@ -168,7 +168,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       - name: object_id
         in: query
         description: object_id
@@ -217,7 +217,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       - name: object_id
         in: query
         description: object_id
@@ -262,7 +262,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       responses:
         200:
           description: successful operation
@@ -293,7 +293,7 @@ paths:
         required: true
         schema:
           type: string
-          default: homo_sapiens_GCA_000001405_27
+          default: homo_sapiens_GCA_000001405_28
       - name: region
         in: query
         description: region to validate
@@ -336,10 +336,10 @@ components:
             $ref: '#/components/schemas/Object/properties/object_id'
         genome_id:
           type: string
-          example: homo_sapiens_GCA_000001405_27
+          example: homo_sapiens_GCA_000001405_28
         image:
           type: string
-          example: http://2020.ensembl.org/static/genome_images/homo_sapiens_GCA_000001405_27.svg
+          example: http://2020.ensembl.org/static/genome_images/homo_sapiens_GCA_000001405_28.svg
         is_available:
           type: boolean
           example: true
@@ -581,7 +581,7 @@ components:
       value:
         bio_type: Protein coding
         description: BRCA2 DNA repair associated
-        genome_id: homo_sapiens_GCA_000001405_27
+        genome_id: homo_sapiens_GCA_000001405_28
         label: BRCA2
         location:
           chromosome: '13'
@@ -594,7 +594,7 @@ components:
         versioned_stable_id: ENSG00000139618.15
     object-info-region-response:
       value:
-        genome_id: homo_sapiens_GCA_000001405_27
+        genome_id: homo_sapiens_GCA_000001405_28
         label: '17:63992802-64038237'
         location:
           chromosome: '17'
@@ -628,14 +628,14 @@ components:
           error_code: null
           error_message: null
           is_valid: true
-          value: homo_sapiens_GCA_000001405_27
+          value: homo_sapiens_GCA_000001405_28
         region:
           error_code: null
           error_message: null
           is_valid: true
           region_code: chromosome
           region_name: '1'
-        region_id: 'homo_sapiens_GCA_000001405_27:region:1:10000-1000000'
+        region_id: 'homo_sapiens_GCA_000001405_28:region:1:10000-1000000'
         start:
           error_code: null
           error_message: null

--- a/blueprints/region_validate.py
+++ b/blueprints/region_validate.py
@@ -272,13 +272,13 @@ class RegionValidate(Resource):
 
 # Tests
 # Valid
-# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_27&region=chromosome%201:123-26365343
+# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_28&region=chromosome%201:123-26365343
 
 # Valid
-# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_27&region=1:123-26365343
+# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_28&region=1:123-26365343
 
 # Valid
-# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_27&region=chromosome%201:123-26365343
+# /api/genome/region/validate?genome_id=homo_sapiens_GCA_000001405_28&region=chromosome%201:123-26365343
 
 
 api.add_resource(RegionValidate, '/validate')

--- a/configs/additional_configs.yaml
+++ b/configs/additional_configs.yaml
@@ -1,6 +1,6 @@
 ASSOCIATED_ASSEMBLIES:
       human:
-          - 'homo_sapiens_GCA_000001405_27'
+          - 'homo_sapiens_GCA_000001405_28'
           - 'homo_sapiens_GCA_000001405_14'
       test:
           - 'wheat_test1'
@@ -10,7 +10,7 @@ ASSOCIATED_ASSEMBLIES:
           - 'wheat_test5'
           - 'wheat_test6'
 POPULAR_GENOMES:
-      - 'homo_sapiens_GCA_000001405_27'
+      - 'homo_sapiens_GCA_000001405_28'
       - 'mus_musculus_GCA_000001635_8'
       - 'triticum_aestivum_GCA_900519105_1'
       - 'homo_sapiens_GCA_000001405_14'
@@ -53,7 +53,7 @@ POPULAR_GENOMES:
       - 'salpingoeca_rosetta_GCA_000188695_1'
       - 'plasmodium_falciparum_GCA_000002765_2'
 AVAILABLE_GENOMES:
-      'homo_sapiens_GCA_000001405_27':
+      'homo_sapiens_GCA_000001405_28':
               Gene: 'ENSG00000139618'
               Region: '17:63992802-64038237'
       'homo_sapiens_GCA_000001405_14':

--- a/configs/core_config.yaml
+++ b/configs/core_config.yaml
@@ -45,7 +45,7 @@ GENOME_ID_VALID_CHARS: 'A-Za-z0-9'
 
 
 
-V_VERSION: 96
+V_VERSION: 98
 
 METADATA_REGISTRY_URL: 'http://test-metadata.ensembl.org/genome'
 

--- a/configs/flask_endpoints_tmp_configs/example_objects.yaml
+++ b/configs/flask_endpoints_tmp_configs/example_objects.yaml
@@ -1,4 +1,4 @@
-homo_sapiens_GCA_000001405_27:
+homo_sapiens_GCA_000001405_28:
   Gene:
     ENSG00000139618:
       label: 'BRCA2'

--- a/configs/flask_endpoints_tmp_configs/track_categories.yaml
+++ b/configs/flask_endpoints_tmp_configs/track_categories.yaml
@@ -1,5 +1,5 @@
 genome_track_categories:
-  homo_sapiens_GCA_000001405_27:
+  homo_sapiens_GCA_000001405_28:
     - label: 'Genes & transcripts'
       track_category_id: 'genes-transcripts'
       track_list:

--- a/dump_karyotypes.py
+++ b/dump_karyotypes.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
             json.dump(regions_info,kf)
 
     """
-    genomes = {'homo_sapiens':'homo_sapiens_GCA_000001405_27', \
+    genomes = {'homo_sapiens':'homo_sapiens_GCA_000001405_28', \
                 'triticum_aestivum':'triticum_aestivum_GCA_900519105_1', \
                 'plasmodium_falciparum':'plasmodium_falciparum_GCA_000002765_2', \
                 'escherichia_coli':'escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2', \

--- a/region_info_store.json
+++ b/region_info_store.json
@@ -242,7 +242,7 @@
             }
         }
     },
-    "homo_sapiens_GCA_000001405_27": {
+    "homo_sapiens_GCA_000001405_28": {
         "chromosome": {
             "1": {
                 "is_chromosome": true,

--- a/tests/test_alternative_assemblies.py
+++ b/tests/test_alternative_assemblies.py
@@ -30,7 +30,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if alternative assemblies endpoint works ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28'
         response = self.app.get(self.base_url + query)
 
         print('\t*** Request: {} ***'.format(self.base_url + query))

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if genome/info endpoint works ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28'
         response = self.app.get(self.base_url + query)
 
         print('\t*** Request: {} ***'.format(self.base_url + query))
@@ -49,7 +49,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if genome/info endpoint works with multiple genome ids ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27&genome_id=triticum_aestivum_GCA_900519105_1&genome_id=homo_sapiens_GCA_000001405_14&genome_id=escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28&genome_id=triticum_aestivum_GCA_900519105_1&genome_id=homo_sapiens_GCA_000001405_14&genome_id=escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2'
         response = self.app.get(self.base_url + query)
 
         print('\t*** Request: {} ***'.format(self.base_url + query))
@@ -70,7 +70,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if genome/track_categories endpoint works ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28'
 
         response = self.app.get(self.base_url + query)
 

--- a/tests/test_object_related.py
+++ b/tests/test_object_related.py
@@ -33,7 +33,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if object/info endpoint works ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27&type=gene&stable_id=ENSG00000139618'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28&type=gene&stable_id=ENSG00000139618'
         response = self.app.get(self.base_url + query)
 
         print('\t*** Request: {} ***'.format(self.base_url + query))
@@ -49,7 +49,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if object/track_list endpoint works ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_27&type=gene&stable_id=ENSG00000139618'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28&type=gene&stable_id=ENSG00000139618'
 
         response = self.app.get(self.base_url + query)
 


### PR DESCRIPTION
Thoas has the data for release 100 and with that genome_id for GRCh38 is homo_sapiens_GCA_000001405_28
Currently, genome-search has data from release 96 which has genome_id for GRCh38 as homo_sapiens_GCA_000001405_27
This causes the problem for integrating thoas as the genome_id for GRCh38 is different

Related JIRA https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-659

- Change genome_id for GRCh38 from homo_sapiens_GCA_000001405_27 to homo_sapiens_GCA_000001405_28

- Remove jobs which deploys genome-search to EHK cluster - We no longer use EHK

- Use k8s manifests from enesmbl-web namespace (Moving k8s manifests from personal repo to enesmbl-web namespace in gitlab)

- Add job to deploy genome-search to enesmbl-dev namespace at WP-HX k8s cluster (Used for development where FE connects to)