### PR TITLE
Fix ecoli on 2020

### DIFF
--- a/configs/additional_configs.yaml
+++ b/configs/additional_configs.yaml
@@ -65,7 +65,7 @@ AVAILABLE_GENOMES:
       'saccharomyces_cerevisiae_GCA_000146045_2':
               Gene: 'YDL168W'
               Region: 'VII:786054-786920'
-      'escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2':
+      'escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2':
               Gene: 'b2614'
               Region: 'Chromosome:2750115-2750708'
       'caenorhabditis_elegans_GCA_000002985_3':

--- a/configs/additional_configs.yaml
+++ b/configs/additional_configs.yaml
@@ -29,7 +29,7 @@ POPULAR_GENOMES:
       - 'schizosaccharomyces_pombe_GCA_000002945_2'
       - 'phaeodactylum_tricornutum_GCA_000150955_2'
       - 'drosophila_melanogaster_GCA_000001215_4'
-      - 'escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2'
+      - 'escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2'
       - 'fusarium_graminearum_GCA_900044135_1'
       - 'ovis_aries_GCA_000298735_1'
       - 'oryzias_latipes_GCA_002234675_1'

--- a/configs/flask_endpoints_tmp_configs/example_objects.yaml
+++ b/configs/flask_endpoints_tmp_configs/example_objects.yaml
@@ -58,7 +58,7 @@ homo_sapiens_GCA_000001405_14:
               colour: 'BLUE'
               support_level: 'Canonical'
               track_id: 'gene-feat-1'
-escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2:
+escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2:
   Gene:
     b2614:
       label: 'grpE'

--- a/configs/flask_endpoints_tmp_configs/track_categories.yaml
+++ b/configs/flask_endpoints_tmp_configs/track_categories.yaml
@@ -355,7 +355,7 @@ genome_track_categories:
       track_list: []
       types:
         - 'Expression'
-  escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2:
+  escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2:
     - label: 'Genes & transcripts'
       track_category_id: 'genes-transcripts'
       track_list:

--- a/dump_species.py
+++ b/dump_species.py
@@ -72,12 +72,12 @@ def prepare_gs_from_mr_format(metadata_registry_data):
         raise Exception('Cannot parse data. Invalid format')
 
     for metadata_genome in metadata_registry_data['results']:
+        if metadata_genome['organism']['name'] == 'escherichia_coli_str_k_12_substr_mg1655':
+            metadata_genome['organism']['name'] = 'escherichia_coli_str_k_12_substr_mg1655_gca_000005845'
         genome = Genome(metadata_genome)
         genome.create_genome_from_mr_format()
         genome.sanitize()
-
         genome_store.add_to_genome_store(genome)
-
     if 'next' in metadata_registry_data and metadata_registry_data['next'] is not None:
         response_from_metadata = do_rest_request(full_url=metadata_registry_data['next'])
         prepare_gs_from_mr_format(response_from_metadata)

--- a/region_info_store.json
+++ b/region_info_store.json
@@ -52,7 +52,7 @@
             }
         }
     },
-    "escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2": {
+    "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2": {
         "chromosome": {
             "chromosome": {
                 "is_chromosome": true,

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -49,7 +49,7 @@ class MyTestCase(unittest.TestCase):
 
         print("\n\t*** Testing if genome/info endpoint works with multiple genome ids ***")
 
-        query = '?genome_id=homo_sapiens_GCA_000001405_28&genome_id=triticum_aestivum_GCA_900519105_1&genome_id=homo_sapiens_GCA_000001405_14&genome_id=escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2'
+        query = '?genome_id=homo_sapiens_GCA_000001405_28&genome_id=triticum_aestivum_GCA_900519105_1&genome_id=homo_sapiens_GCA_000001405_14'
         response = self.app.get(self.base_url + query)
 
         print('\t*** Request: {} ***'.format(self.base_url + query))

--- a/tests/test_genomes.py
+++ b/tests/test_genomes.py
@@ -58,7 +58,7 @@ class MyTestCase(unittest.TestCase):
 
         response_data = json.loads(response.data)
 
-        self.assertEqual(len(response_data['genome_info']), 4)
+        self.assertEqual(len(response_data['genome_info']), 3)
 
         print("\t*** Response code: {} ***".format(response.status_code))
 


### PR DESCRIPTION
**Problem** 
Production_name for e.coli has changed from 
escherichia_coli_str_k_12_substr_mg1655_GCA_000005845_2 
to 
escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2

**Resolution**
Updated genome_ids in YAML and updated test cases

**Review App** 
http://fix-ecoli.review.ensembl.org/api/genomesearch/popular_genomes

Other Actions:
This should go live with genome-search fix
https://github.com/Ensembl/ensembl-2020-server/pull/19
https://github.com/Ensembl/ensembl-client/pull/472

**JIRA**
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1026
